### PR TITLE
MSVC support for libtree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ soname		= libtree.so.$(MAJOR_VERSION)
 ARFLAGS		= cr
 LDFLAGS		= -Wl,--version-script=libtree.map
 CFLAGS		= -g -Os
-BASE_CFLAGS	= -std=c99 -Wall -Werror -Wno-unused-function -fpic
+BASE_CFLAGS	= -ansi -pedantic -Wall -Werror -Wno-unused-function -fpic
 ALL_CFLAGS	= $(BASE_CFLAGS) $(CFLAGS) $(EXTRA_CFLAGS)
 
 libtree_srcs	= bst.c rb.c avl.c splay.c

--- a/avl.c
+++ b/avl.c
@@ -25,6 +25,10 @@
 
 #if !defined UINTPTR_MAX || UINTPTR_MAX != UINT64_MAX
 
+#ifdef WIN32
+#define inline __inline
+#endif
+
 static inline int is_root(struct avltree_node *node)
 {
 	return node->parent == NULL;

--- a/bst.c
+++ b/bst.c
@@ -32,6 +32,10 @@
 
 #define NODE_INIT	{ 0, }
 
+#ifdef WIN32
+#define inline __inline
+#endif
+
 static inline void INIT_NODE(struct bstree_node *node)
 {
 	node->left = 0;

--- a/libtree.h
+++ b/libtree.h
@@ -40,6 +40,9 @@
 #  define splaytree_container_of(node, type, member) ({			\
 	const struct splaytree_node *__mptr = (node);			\
 	(type *)( (char *)__mptr - offsetof(type,member) );})
+#  if __STRICT_ANSI__
+#    define inline __inline__
+#  endif
 #else
 #  define bstree_container_of(node, type, member)			\
 	((type *)((char *)(node) - offsetof(type, member)))
@@ -95,7 +98,7 @@ int bstree_init(struct bstree *tree, bstree_cmp_fn_t cmp, unsigned long flags);
  */
 enum rb_color {
 	RB_BLACK,
-	RB_RED,
+	RB_RED
 };
 
 #ifdef UINTPTR_MAX

--- a/libtree.h
+++ b/libtree.h
@@ -87,7 +87,7 @@ struct bstree_node *bstree_prev(const struct bstree_node *node);
 struct bstree_node *bstree_lookup(const struct bstree_node *key, const struct bstree *tree);
 struct bstree_node *bstree_insert(struct bstree_node *node, struct bstree *tree);
 void bstree_remove(struct bstree_node *node, struct bstree *tree);
-void bstree_replace(struct bstree_node *old, struct bstree_node *new, struct bstree *tree);
+void bstree_replace(struct bstree_node *old, struct bstree_node *newnode, struct bstree *tree);
 int bstree_init(struct bstree *tree, bstree_cmp_fn_t cmp, unsigned long flags);
 
 /*
@@ -132,7 +132,7 @@ struct rbtree_node *rbtree_prev(const struct rbtree_node *node);
 struct rbtree_node *rbtree_lookup(const struct rbtree_node *key, const struct rbtree *tree);
 struct rbtree_node *rbtree_insert(struct rbtree_node *node, struct rbtree *tree);
 void rbtree_remove(struct rbtree_node *node, struct rbtree *tree);
-void rbtree_replace(struct rbtree_node *old, struct rbtree_node *new, struct rbtree *tree);
+void rbtree_replace(struct rbtree_node *old, struct rbtree_node *newnode, struct rbtree *tree);
 int rbtree_init(struct rbtree *tree, rbtree_cmp_fn_t cmp, unsigned long flags);
 
 /*
@@ -173,7 +173,7 @@ struct avltree_node *avltree_prev(const struct avltree_node *node);
 struct avltree_node *avltree_lookup(const struct avltree_node *key, const struct avltree *tree);
 struct avltree_node *avltree_insert(struct avltree_node *node, struct avltree *tree);
 void avltree_remove(struct avltree_node *node, struct avltree *tree);
-void avltree_replace(struct avltree_node *old, struct avltree_node *new, struct avltree *tree);
+void avltree_replace(struct avltree_node *old, struct avltree_node *newnode, struct avltree *tree);
 int avltree_init(struct avltree *tree, avltree_cmp_fn_t cmp, unsigned long flags);
 
 /*
@@ -212,7 +212,7 @@ struct splaytree_node *splaytree_prev(const struct splaytree_node *node);
 struct splaytree_node *splaytree_lookup(const struct splaytree_node *key, struct splaytree *tree);
 struct splaytree_node *splaytree_insert( struct splaytree_node *node, struct splaytree *tree);
 void splaytree_remove(struct splaytree_node *node, struct splaytree *tree);
-void splaytree_replace(struct splaytree_node *old, struct splaytree_node *new, struct splaytree *tree);
+void splaytree_replace(struct splaytree_node *old, struct splaytree_node *newnode, struct splaytree *tree);
 int splaytree_init(struct splaytree *tree, splaytree_cmp_fn_t cmp, unsigned long flags);
 
 #endif /* _LIBTREE_H */

--- a/rb.c
+++ b/rb.c
@@ -46,12 +46,12 @@ static inline enum rb_color get_color(const struct rbtree_node *node)
 
 static inline void set_color(enum rb_color color, struct rbtree_node *node)
 {
-	node->parent = (node->parent & ~1UL) | color;
+	node->parent = (node->parent & -2) | color;
 }
 
 static inline struct rbtree_node *get_parent(const struct rbtree_node *node)
 {
-	return (struct rbtree_node *)(node->parent & ~1UL);
+	return (struct rbtree_node *)(node->parent & -2);
 }
 
 static inline void set_parent(struct rbtree_node *parent, struct rbtree_node *node)

--- a/rb.c
+++ b/rb.c
@@ -35,6 +35,10 @@
  */
 #ifdef UINTPTR_MAX
 
+#ifdef WIN32
+#define inline __inline
+#endif
+
 static inline enum rb_color get_color(const struct rbtree_node *node)
 {
 	return node->parent & 1;

--- a/splay.c
+++ b/splay.c
@@ -27,6 +27,10 @@
 
 #define NODE_INIT	{ 0, }
 
+#ifdef WIN32
+#define inline __inline
+#endif
+
 static inline void INIT_NODE(struct splaytree_node *node)
 {
 	node->left = 0;


### PR DESCRIPTION
Here are some changes that add support to let libtree compile on Visual Studio on Windows. I've split them up into a few commits this time.

I found an issue where the masking of pointer that have packed colour information in the bottom bit wasn't working right when longs are shorter than pointers, which is the case on 64 bit Windows.

You comments are appreciated.
